### PR TITLE
Prefix release tags with v for Go module compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,11 @@ version:
 	@echo "current version: ${version}"
 
 # display the current release information
+# tags are prefixed with v (vX.Y.Z) as required by the go module resolver
 release: oobt version
-	git tag -a ${version}
-	git push origin ${version}
-	@echo "create release: ${version}"
+	git tag -a v${version}
+	git push origin v${version}
+	@echo "create release: v${version}"
 
 clean:
 	rm coverage.out


### PR DESCRIPTION
Fixes #3 (tagging convention half — see caveat below).

## Problem

The `release` target tagged `${version}` verbatim, producing tags like `1.1.0`. Go modules [require the `v` prefix](https://go.dev/ref/mod#versions) to resolve a tag as a semantic version, so consumers fell back to pseudo-versions:

```go
require github.com/serpapi/serpapi-golang v0.0.0-20260126142127-0e41c7993cda
```

## Change

Prefix the tag with `v` at the tagging site only:

```make
release: oobt version
	git tag -a v${version}
	git push origin v${version}
```

`VERSION` in `serpapi.go` deliberately stays bare — it is sent as the `source=go:1.1.0` API parameter, so the prefix belongs on the git tag rather than in the constant.

Verified with `make -n release`, which now expands to `git tag -a v1.1.0`.

## Caveat — this alone does not close the issue

The issue also asks for `v`-prefixed tags on the *existing* release commits. Those have to be pushed by hand and are not part of this diff:

```bash
git tag -a v1.0.0 44cda64 -m "Official SerpApi client wrapper (new API version 1.0.0)"
git tag -a v1.1.0 0e41c79 -m "release version 1.1.0"
git push origin v1.0.0 v1.1.0
```

Note that `v1.1.0` above points at master's tip rather than at the commit the existing `1.1.0` tag references — that tag points to an off-master commit predating the `remove-num-param` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)