### PR TITLE
Fix mermaid block syntax on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2051,9 +2051,10 @@ classDiagram
     search_archive() Map
     account() Map
   }
-  net/http <.. Client
+  class nethttp["net/http"]
+  nethttp <.. Client
   json <.. Client
-  Go <.. net/http
+  Go <.. nethttp
   Go <.. json
 ```
 ### search() : Sequence diagram

--- a/README.md.erb
+++ b/README.md.erb
@@ -412,9 +412,10 @@ classDiagram
     search_archive() Map
     account() Map
   }
-  net/http <.. Client
+  class nethttp["net/http"]
+  nethttp <.. Client
   json <.. Client
-  Go <.. net/http
+  Go <.. nethttp
   Go <.. json
 ```
 ### search() : Sequence diagram


### PR DESCRIPTION
Fixes the syntax issue on the mermaid diagram.

Before:
<img width="1144" height="936" alt="image" src="https://github.com/user-attachments/assets/8d4e58a8-022f-4102-9eee-1b2fb3100103" />

After:
<img width="1198" height="804" alt="image" src="https://github.com/user-attachments/assets/c324b7b0-7d16-4672-a6c9-76cdd9837a3e" />

